### PR TITLE
[openSUSE] correct return value when libnetcontrol failed to initialize

### DIFF
--- a/src/interface/interface_backend_netcf.c
+++ b/src/interface/interface_backend_netcf.c
@@ -1243,7 +1243,7 @@ int netcfIfaceRegister(void)
      */
     if (ncf_init(&netcf, NULL) != 0) {
         VIR_WARN("Failed to initialize libnetcontrol.  Management of interface devices is disabled");
-        return 0;
+        return -1;
     }
 
     ncf_close(netcf);


### PR DESCRIPTION
Otherwise virtinterfaced will end up in a state without proper interface driver but successful initialization, leading to a hang of "virsh iface-list" (when run as normal user).

References: boo#1219986