### PR TITLE
spec: require the dbus daemon, not dbus-launch

### DIFF
--- a/libvirt.spec
+++ b/libvirt.spec
@@ -345,7 +345,7 @@ Requires:       dmidecode
 # For service management
 %{?systemd_requires}
 # Daemons depend on the 'messagebus' service
-Requires:       dbus-1
+Requires:       dbus-service
 Requires:       group(libvirt)
 # Needed by libvirt-guests init script.
 Requires:       gettext-runtime


### PR DESCRIPTION
`dbus-1` is the dbus-launch utility, not a dbus service, that's `dbus-service`.